### PR TITLE
Add LandSeaMask type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoDatasets"
 uuid = "ddc7317b-88db-5cb5-a849-8449e5df04f9"
 authors = ["Alexander Barth <barth.alexander@gmail.com>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,6 +39,13 @@ savefig("landseamask-coastline-plot.png"); nothing # hide
 
 ![](landseamask-coastline-plot.png)
 
+The `LandSeaMask` type is provided to encapsulate the output from `landseamask`, and
+provides simple functionality to determine whether a particular lat-lon is over land or not:
+```@example
+using GeoDatasets
+mask = GeoDatasets.LandSeaMask(; resolution='c', grid=5)
+GeoDatasets.is_land(52.2, 2.0)
+```
 
 ## Global Self-consistent, Hierarchical, High-resolution Geography Database (gshhg)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -44,7 +44,7 @@ provides simple functionality to determine whether a particular lat-lon is over 
 ```@example
 using GeoDatasets
 mask = GeoDatasets.LandSeaMask(; resolution='c', grid=5)
-GeoDatasets.is_land(52.2, 2.0)
+GeoDatasets.is_land(mask, 52.2, 2.0)
 ```
 
 ## Global Self-consistent, Hierarchical, High-resolution Geography Database (gshhg)

--- a/src/GeoDatasets.jl
+++ b/src/GeoDatasets.jl
@@ -8,52 +8,7 @@ using Shapefile
 using GeoInterface
 using ZipFile
 
-"""
-    lon,lat,data = GeoDatasets.landseamask(;resolution='l',grid=5)
-
-Load the land-sea-lake raster from basemap: 0 is ocean, 1 is land and 2 is lake.
-`grid` is the resolution in arc minutes and should be either 1.25, 2.5, 5 or 10.
-The parameter `resolution` should be either `'c'`,`'l'`,`'i'`,`'h'` or `'f'`
-(standing for crude, low, intermediate, high and full resolution)
-
-The data is downloaded from [basemap](https://github.com/matplotlib/basemap/tree/master/lib/mpl_toolkits/basemap_data).
-
-The data is originally from [GMT](http://gmt.soest.hawaii.edu/) and distributed under the terms of the
-[GPL licences](https://github.com/matplotlib/basemap/blob/a551c2361314670dc7d95143190d3d48ba750d20/LICENSE_data).
-
-```julia
-using GeoDatasets
-lon,lat,data = GeoDatasets.landseamask(;resolution='c',grid=5)
-```
-
-"""
-function landseamask(;resolution='l',grid=5)
-    if !(grid ∈ Set([1.25,2.5,5.,10.]))
-        error("grid should be either 1.25, 2.5, 5 or 10")
-    end
-    if !(resolution ∈ Set(['c','l','i','h','f',"c","l","i","h","f"]))
-        error("resolution should be either 'c','l','i','h' or 'f'")
-    end
-
-    url = "https://raw.githubusercontent.com/matplotlib/basemap/master/lib/mpl_toolkits/basemap_data/lsmask_$(grid)min_$(resolution).bin"
-    @debug "url for landseamask: $url"
-
-    # download remote file if it is not yet available
-    @RemoteFile(lsmask, url)
-    download(lsmask)
-
-    # resolution in arc seconds
-    res = round(Int,grid * 60)
-
-    lon = (-180*3600 + res/2:res:180*3600 - res/2) / 3600
-    lat = (-90*3600 + res/2:res:90*3600 - res/2) / 3600
-
-    data = zeros(UInt8,length(lon)*length(lat));
-    read!(GzipDecompressorStream(open(path(lsmask))),data);
-
-    return lon,lat,reshape(data,length(lon),length(lat))
-end
-
+include("land_sea_mask.jl")
 include("gshhg.jl")
 
 end

--- a/src/land_sea_mask.jl
+++ b/src/land_sea_mask.jl
@@ -1,0 +1,79 @@
+"""
+    lon,lat,data = GeoDatasets.landseamask(;resolution='l',grid=5)
+
+Load the land-sea-lake raster from basemap: 0 is ocean, 1 is land and 2 is lake.
+`grid` is the resolution in arc minutes and should be either 1.25, 2.5, 5 or 10.
+The parameter `resolution` should be either `'c'`,`'l'`,`'i'`,`'h'` or `'f'`
+(standing for crude, low, intermediate, high and full resolution)
+
+The data is downloaded from [basemap](https://github.com/matplotlib/basemap/tree/master/lib/mpl_toolkits/basemap_data).
+
+The data is originally from [GMT](http://gmt.soest.hawaii.edu/) and distributed under the terms of the
+[GPL licences](https://github.com/matplotlib/basemap/blob/a551c2361314670dc7d95143190d3d48ba750d20/LICENSE_data).
+
+```julia
+using GeoDatasets
+lon,lat,data = GeoDatasets.landseamask(;resolution='c',grid=5)
+```
+
+"""
+function landseamask(;resolution='l',grid=5)
+    if !(grid ∈ Set([1.25,2.5,5.,10.]))
+        error("grid should be either 1.25, 2.5, 5 or 10")
+    end
+    if !(resolution ∈ Set(['c','l','i','h','f',"c","l","i","h","f"]))
+        error("resolution should be either 'c','l','i','h' or 'f'")
+    end
+
+    url = "https://raw.githubusercontent.com/matplotlib/basemap/master/lib/mpl_toolkits/basemap_data/lsmask_$(grid)min_$(resolution).bin"
+    @debug "url for landseamask: $url"
+
+    # download remote file if it is not yet available
+    @RemoteFile(lsmask, url)
+    download(lsmask)
+
+    # resolution in arc seconds
+    res = round(Int,grid * 60)
+
+    lon = (-180*3600 + res/2:res:180*3600 - res/2) / 3600
+    lat = (-90*3600 + res/2:res:90*3600 - res/2) / 3600
+
+    data = zeros(UInt8,length(lon)*length(lat));
+    read!(GzipDecompressorStream(open(path(lsmask))),data);
+
+    return lon,lat,reshape(data,length(lon),length(lat))
+end
+
+
+"""
+    LandSeaMask
+
+Encapsulates the `landseamask` data.
+"""
+struct LandSeaMask{Tlon, Tlat, Tdata}
+    lon::Tlon
+    lat::Tlat
+    data::Tdata
+end
+
+function LandSeaMask(; resolution='l', grid=5)
+    return LandSeaMask(GeoDatasets.landseamask(; resolution=resolution, grid=grid)...)
+end
+
+"""
+    is_land(mask::LandSeaMask, lat::Real, lon::Real)
+
+`true` if the nearest lat-lon in the `mask` to `lat`-`lon` is land. Nearest is calculated
+by flooring the lat and lon to the nearest point in the `mask` and return the value of that
+entry.
+"""
+is_land(mask::LandSeaMask, lat::Real, lon::Real) = nearest_point(mask, lat, lon) == 1
+is_land(mask::LandSeaMask, (lat, lon)::Tuple{Real, Real}) = is_land(mask, lat, lon)
+
+function nearest_point(mask::LandSeaMask, lat::Real, lon::Real)
+    return mask.data[nearest_point_idx(mask.lon, lon), nearest_point_idx(mask.lat, lat)]
+end
+
+function nearest_point_idx(xs::StepRangeLen, x::Real)
+    return convert(Int, floor((x - first(xs)) / (last(xs) - first(xs)) * length(xs)))
+end

--- a/src/land_sea_mask.jl
+++ b/src/land_sea_mask.jl
@@ -48,7 +48,7 @@ end
 """
     LandSeaMask
 
-Encapsulates the `landseamask` data.
+Encapsulates the `landseamask` data, and provides the `is_land` function.
 """
 struct LandSeaMask{Tlon, Tlat, Tdata}
     lon::Tlon

--- a/test/land_sea_mask.jl
+++ b/test/land_sea_mask.jl
@@ -1,0 +1,12 @@
+@testset "land_sea_mask" begin
+    lon,lat,data = GeoDatasets.landseamask(;resolution='c',grid=5)
+    @test size(data,1) == length(lon)
+    @test size(data,2) == length(lat)
+
+    @test_throws ErrorException GeoDatasets.landseamask(;resolution='c',grid=-999)
+    @test_throws ErrorException GeoDatasets.landseamask(;resolution='g',grid=5)
+
+    mask = GeoDatasets.LandSeaMask()
+    @test GeoDatasets.is_land(mask, 52.200475, 0.1138)
+    @test !GeoDatasets.is_land(mask, 56.615841, 3.39206)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,6 @@
 using Test, GeoDatasets
 
-
-@testset "landseamask" begin
-    lon,lat,data = GeoDatasets.landseamask(;resolution='c',grid=5)
-    @test size(data,1) == length(lon)
-    @test size(data,2) == length(lat)
-
-    @test_throws ErrorException GeoDatasets.landseamask(;resolution='c',grid=-999)
-    @test_throws ErrorException GeoDatasets.landseamask(;resolution='g',grid=5)
-end
-
+include("land_sea_mask.jl")
 
 @testset "gshhg" begin
     res = 'c'
@@ -20,4 +11,3 @@ end
     # resolution 'x' does not exists
     @test_throws ErrorException GeoDatasets.gshhg('x',[1,5])
 end
-


### PR DESCRIPTION
As discussed in #14 , this adds some encapsulation to the land-sea mask data and provides an `is_land` function. One question I have is whether this is the correct / most intuitive way to implement the `is_land` function / whether there are better options available.

Once we've agreed on the basics, I'll add some tests and bump the patch version (this isn't breaking) so that we can get a release out.