### PR TITLE
Proposed changes to project scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGeo.github.io/GeoDatasets.jl/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGeo.github.io/GeoDatasets.jl/dev)
 
-The aim of this package is to give access to common geographics datasets. Currently it contains:
+The aim of this package is to give access to common geographic and geoscience datasets. Currently it contains:
 * the global land-sea-river mask from [GMT](http://gmt.soest.hawaii.edu/)
 * the [Global Self-consistent, Hierarchical, High-resolution Geography Database (gshhg)](https://www.soest.hawaii.edu/pwessel/gshhg/).
 
-Contributions are most welcome. Here are some guidelines:
-* data sets should be global in scope
-* available under a license allowing redistribution
-* hosted on a publicly available server
+Contributions are most welcome. Data should be:
+* curated by a trusted (for example government) source;
+* of general interest to the geography or geoscience communities;
+* available under a license allowing redistribution; and
+* hosted on a publicly available server.
 
 
 # Installation


### PR DESCRIPTION
Let me know what you think of these changes. Key points:

* Changed from "geography" to "geography and geoscience"
* Removed the requirement for global scope and replaced with "of general interest to the community". Some important datasets are regional in scope (e.g. geostationary satellites), some global work is done by stitching together regional datasets, and regardless importat work is also done at the regional and urban scales. So I propose that decisions for including datasets are done on a case by case basis by evaluating tradeoffs between utility and scope creep etc.